### PR TITLE
Fix short address decoding

### DIFF
--- a/solidity/libraries/RLP.sol
+++ b/solidity/libraries/RLP.sol
@@ -125,13 +125,10 @@ library RLP {
         view
         returns (address data)
     {
-        uint rStartPos;
         uint len;
-        (rStartPos, len) = _decode(self);
-        require(len == 20);
-        assembly {
-            data := div(mload(rStartPos), exp(256, 12))
-        }
+        (, len) = _decode(self);
+        require(len <= 20);
+        return address(toUint(self));
     }
 
     /// @dev Return the RLP encoded bytes.


### PR DESCRIPTION
Example addresses:
```
0x0014F55A50b281EFD12294f0Cda821Bd8171e920
0x0000000000000000000000000000000000000000
```